### PR TITLE
fix(contract): support isPresent.assess import without assure

### DIFF
--- a/src/checks/isPresent.assess.ts
+++ b/src/checks/isPresent.assess.ts
@@ -1,0 +1,8 @@
+import { isNotNull, NotNull } from './isNotNull';
+import { IsDefined, isDefined } from './isNotUndefined';
+
+const assess = <T>(t: T): t is NotNull<IsDefined<T>> =>
+  isNotNull(t) && isDefined(t);
+
+// export for direct usage, without assure
+export { assess as isPresentAssess };

--- a/src/checks/isPresent.ts
+++ b/src/checks/isPresent.ts
@@ -1,9 +1,8 @@
 import { asAssure } from '../wrappers/withAssure';
-import { NotNull, isNotNull } from './isNotNull';
-import { IsDefined, isDefined } from './isNotUndefined';
+import { NotNull } from './isNotNull';
+import { IsDefined } from './isNotUndefined';
+import { isPresentAssess as assess } from './isPresent.assess';
 
-const assess = <T>(t: T): t is NotNull<IsDefined<T>> =>
-  isNotNull(t) && isDefined(t);
 const assure = asAssure(assess, { name: 'isPresent' });
 
 interface IsPresentWithAssure {


### PR DESCRIPTION
enables helpful-errors to leverage isPresent without risk of cyclical-dependency error, since "assure" leverages helpful-error